### PR TITLE
1.20.3-1.20.4 Compatability

### DIFF
--- a/fabric-forge/data/watching/tags/blocks/air_blocks.json
+++ b/fabric-forge/data/watching/tags/blocks/air_blocks.json
@@ -10,7 +10,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/fabric-forge/data/watching/tags/blocks/glass_sight_blocks.json
+++ b/fabric-forge/data/watching/tags/blocks/glass_sight_blocks.json
@@ -48,7 +48,7 @@
         "minecraft:acacia_sapling",
         "minecraft:dark_oak_sapling",
         "minecraft:cobweb",
-        "minecraft:grass",
+        "minecraft:short_grass",
         "minecraft:fern",
         "minecraft:dead_bush",
         "minecraft:seagrass",

--- a/fabric-forge/data/watching/tags/blocks/sight_blocks.json
+++ b/fabric-forge/data/watching/tags/blocks/sight_blocks.json
@@ -13,7 +13,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/fabric-forge/data/watching/tags/blocks/spawning_raycast/no_col_blocks.json
+++ b/fabric-forge/data/watching/tags/blocks/spawning_raycast/no_col_blocks.json
@@ -12,7 +12,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/fabric-forge/data/watching/tags/blocks/torch_nonspawn_blocks.json
+++ b/fabric-forge/data/watching/tags/blocks/torch_nonspawn_blocks.json
@@ -13,7 +13,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/vanilla/data/watching/tags/blocks/air_blocks.json
+++ b/vanilla/data/watching/tags/blocks/air_blocks.json
@@ -10,7 +10,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/vanilla/data/watching/tags/blocks/glass_sight_blocks.json
+++ b/vanilla/data/watching/tags/blocks/glass_sight_blocks.json
@@ -48,7 +48,7 @@
         "minecraft:acacia_sapling",
         "minecraft:dark_oak_sapling",
         "minecraft:cobweb",
-        "minecraft:grass",
+        "minecraft:short_grass",
         "minecraft:fern",
         "minecraft:dead_bush",
         "minecraft:seagrass",

--- a/vanilla/data/watching/tags/blocks/sight_blocks.json
+++ b/vanilla/data/watching/tags/blocks/sight_blocks.json
@@ -13,7 +13,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/vanilla/data/watching/tags/blocks/spawning_raycast/no_col_blocks.json
+++ b/vanilla/data/watching/tags/blocks/spawning_raycast/no_col_blocks.json
@@ -12,7 +12,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",

--- a/vanilla/data/watching/tags/blocks/torch_nonspawn_blocks.json
+++ b/vanilla/data/watching/tags/blocks/torch_nonspawn_blocks.json
@@ -13,7 +13,7 @@
   "minecraft:acacia_sapling",
   "minecraft:dark_oak_sapling",
   "minecraft:cobweb",
-  "minecraft:grass",
+  "minecraft:short_grass",
   "minecraft:fern",
   "minecraft:dead_bush",
   "minecraft:seagrass",


### PR DESCRIPTION
The name of `minecraft:grass` has changed to be `minecraft:short_grass`. Here is an example log report of the errors in console:

```
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag watching:sight_blocks as it is missing following references: minecraft:grass (from file/From-The-Fog-1.20-v1.9.2-Data-Resource-Pack.zip.zip)
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag watching:glass_sight_blocks as it is missing following references: minecraft:grass (from file/From-The-Fog-1.20-v1.9.2-Data-Resource-Pack.zip.zip)
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag enchantplus:not_solid as it is missing following references: minecraft:grass (from file/technical-enchant-v7-4-0_1.20.2.zip)
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag watching:air_blocks as it is missing following references: minecraft:grass (from file/From-The-Fog-1.20-v1.9.2-Data-Resource-Pack.zip.zip)
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag watching:torch_nonspawn_blocks as it is missing following references: minecraft:grass (from file/From-The-Fog-1.20-v1.9.2-Data-Resource-Pack.zip.zip)
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag watching:spawning_raycast/no_col_blocks as it is missing following references: minecraft:grass (from file/From-The-Fog-1.20-v1.9.2-Data-Resource-Pack.zip.zip)
[23.12 14:56:33] [Server] [Worker-Main-14/ERROR]: Couldn't load tag enchantplus:scyther/hoe_mineable as it is missing following references: minecraft:grass (from file/technical-enchant-v7-4-0_1.20.2.zip)
```

Here is the patch note from the official website: https://www.minecraft.net/en-us/article/minecraft-java-edition-1-20-3

> Renamed minecraft:grass block and item to minecraft:short_grass

I changed all the references to `minecraft:grass` to `minecraft:short_grass` and there are no longer any errors in console.